### PR TITLE
Update hdf5

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,9 +25,6 @@
 [submodule "submodules/tokyocabinet"]
 	path = submodules/tokyocabinet
 	url = git://github.com/UCSCReconGroup/tokyocabinet.git
-[submodule "submodules/hdf5"]
-	path = submodules/hdf5
-	url = git://github.com/UCSCReconGroup/hdf5.git
 [submodule "submodules/kyotocabinet"]
 	path = submodules/kyotocabinet
 	url = git://github.com/UCSCReconGroup/kyotocabinet.git

--- a/submodules/Makefile
+++ b/submodules/Makefile
@@ -84,9 +84,9 @@ kentToolBinariesRule :
 	echo export PATH=$(PWD)/kentToolBinaries:\$$PATH >> ${myEnv}
 
 hdf5Rule :
-	cd hdf5 &&./configure --prefix=$(PWD)/hdf5 --enable-cxx && CFLAGS=-std=c99 make -e && make install
+	if [ ! -d "hdf5" ]; then wget http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.1/src/hdf5-1.10.1.tar.gz && tar zxf hdf5-1.10.1.tar.gz && mv hdf5-1.10.1 hdf5; fi
+	cd hdf5 &&./configure --prefix=$(PWD)/hdf5 --enable-cxx && CFLAGS=-std=c99 make -e && make install	
 	echo export PATH=$(PWD)/hdf5/bin:\$$PATH >> ${myEnv}
-
 
 # Important to export environment to override sonlib/include.mk
 export
@@ -141,7 +141,7 @@ kentToolBinariesClean :
 	cd kentToolBinaries && make clean
 
 hdf5Clean:
-	cd hdf5 && make clean
+	rm -rf hdf5
 
 test: ${ucscModules:%=test.%}
 

--- a/submodules/Makefile
+++ b/submodules/Makefile
@@ -23,6 +23,7 @@ virtPyRule :
 	cp ${virtPyEnv} ${myEnv}
 	echo export PYTHONPATH=$(PWD):\$$PYTHONPATH >> ${myEnv}
 	echo export PATH=${virtPyDir}/bin:\$$PATH >> ${myEnv}
+	echo export PYTHONPATH=$(PWD)/biopython:\$$PYTHONPATH >> ${myEnv}
 
 ifeq ($(enablePBSTorque), yes)
 pbsDrmaaRule :


### PR DESCRIPTION
Upgrade hdf5 to latest release (1.10.1).  This one seems to build better with newer compilers.

Also: now downloading hdf5 release directly, rather than going through a git submodule.  This requires wget.  