### PR TITLE
Fix for #104, resubmitting a job when using relative dirs.

### DIFF
--- a/src/projectWrapper.py
+++ b/src/projectWrapper.py
@@ -188,6 +188,11 @@ class ProjectWrapper:
             return False
         oldPath = os.path.dirname(projPath + "/")
         tempPath = "%s_temp" % oldPath
+        # Fix for relative directories
+        if oldPath[0:2] == './':
+            oldPath = oldPath[2:]
+        if tempPath[0:2] == './':
+            tempPath = tempPath[2:]
         if os.path.exists(tempPath):
             system("rm -rf %s" % tempPath)
         cmd = "cactus_createMultiCactusProject.py %s %s --fixNames=%d" % (


### PR DESCRIPTION
This is a fix for #104, #16, #51, and addresses one of the comments in #38.  This pull request should help many other people be able to resume their jobs.  In short, it allows for resuming a job when the job was submitted with a leading "./" on the working directory.

The example on the README page is what is tripping everyone up.

When you try to restart a job that was submitted like this:

bin/runProgressiveCactus.sh examples/blanchette00.txt ./work ./work/b00.hal

then the replace() call here: can't

newLine.replace(tempPath, oldPath)

can't do its job.  It's trying to replace "./work" inside of

/some/long/path/to/work/progressiveAlignment_temp/Anc0/Anc0_experiment.xml

This commit just removes the leading "./" from those paths if they
exist, allowing the job to resume correctly.